### PR TITLE
Add Multi-arch and Gemini support

### DIFF
--- a/config/gradle_test_generation_gemini.yaml
+++ b/config/gradle_test_generation_gemini.yaml
@@ -1,0 +1,194 @@
+# Gemini-compatible variant of gradle_test_generation.yaml
+# Omits cache_control history processor (incompatible with Gemini's CachedContent API)
+agent:
+  type: default
+  templates:
+    system_template: |-
+      You are an expert in Gradle build systems and test generation. Your task is to generate Gradle Test Kit tests that verify specific build script changes.
+
+      You have deep knowledge of:
+      - Gradle build configuration (build.gradle, build.gradle.kts)
+      - Version catalog files (libs.versions.toml)
+      - Dependency management and version updates
+      - Plugin configuration
+      - Gradle Test Kit APIs for functional testing
+      - Git commands for inspecting repository changes
+
+      Your tests must be precise and verify the EXACT changes present in the repository, not generic build validation.
+    instance_template: |-
+      <uploaded_files>
+      {{working_dir}}
+      </uploaded_files>
+      I've uploaded a Kotlin/Android Gradle project in the directory {{working_dir}}.
+
+      ## Task: Generate a Gradle Test Kit Test
+
+      You need to create a test that verifies a specific Gradle build configuration change that has already been applied to this repository.
+
+      ### Problem Statement
+      <problem_statement>
+      {{problem_statement}}
+      </problem_statement>
+
+      ### Discovering the Changes (CRITICAL - Read Carefully!)
+
+      The build configuration has already been modified. To understand what changed, you MUST:
+
+      1. **Use git to inspect the changes**: Run `git diff HEAD~1` or `git show HEAD` to see the exact modifications
+      2. **Identify the specific change**: Look for version updates, new dependencies, configuration changes, etc.
+      3. **Note the exact values**: Record both the old value (if visible in git history) and the new value currently in the files
+
+      ## Your Goal
+
+      Generate a **single Java test class** using Gradle Test Kit that:
+      1. **PASSES** when run against the **current** build script (with the applied changes)
+      2. Would **FAIL** if the changes were reverted
+
+      The test must verify the **specific change** you discovered, NOT just "builds successfully".
+
+      ## Verification Strategies (Choose Based on Change Type)
+
+      After discovering the changes using git, select the appropriate verification strategy:
+
+      ### 1. Dependency Version Changes (libs.versions.toml or build.gradle)
+      If the patch updates a dependency version (e.g., `mockito_core = "5.20.0"` → `"5.21.0"`):
+      ```java
+      // Read the build file or version catalog and check for the specific version string
+      String content = Files.readString(buildFilePath);
+      assertTrue(content.contains("5.21.0"), "Expected version 5.21.0 but found older version");
+      ```
+
+      ### 2. New Dependency Added
+      If the patch adds a new dependency (e.g., `implementation("androidx.navigation:navigation-compose:2.6.0")`):
+      ```java
+      // Check the build file contains the new dependency
+      String content = Files.readString(buildFilePath);
+      assertTrue(content.contains("navigation-compose"), "Expected navigation-compose dependency to be present");
+      ```
+
+      ### 3. Plugin Version Changes
+      If the patch updates a plugin version:
+      ```java
+      // Check the build file contains the new plugin version
+      String content = Files.readString(buildFilePath);
+      assertTrue(content.contains("5.4.0"), "Expected plugin version 5.4.0");
+      ```
+
+      ### 4. Configuration Value Changes (compileSdk, minSdk, versionCode, etc.)
+      If the patch changes configuration values:
+      ```java
+      // Check for the specific configuration value
+      String content = Files.readString(buildFilePath);
+      assertTrue(content.contains("versionCode = 40"), "Expected versionCode 40");
+      ```
+
+      ### 5. Module/Project Dependencies
+      If the patch adds project dependencies (e.g., `implementation(projects.core.ui)`):
+      ```java
+      // Check for the project dependency
+      String content = Files.readString(buildFilePath);
+      assertTrue(content.contains("projects.core.ui"), "Expected projects.core.ui dependency");
+      ```
+
+      ## Critical Constraints - DO NOT VIOLATE
+
+      **FORBIDDEN ACTIONS** - Your test must NOT:
+      - Adding comments to the test file
+      - Modify any project files (source code, resources, configuration files, etc.) UNLESS it is strictly necessary for test setup
+        - ALLOWED: Adding test dependencies and test configuration to root build.gradle or build.gradle.kts (as shown in step 5)
+        - ALLOWED: Creating the test file itself (BuildScriptTest.java)
+        - FORBIDDEN: Modifying application source code, existing build files of modules/subprojects, version catalogs, or any other project files
+
+      ## Steps to Complete
+
+      1. **Discover the changes**: Run `git diff HEAD~1` or `git show HEAD` to see what was modified
+      2. **Analyze the changes carefully**: Identify EXACTLY what changed (version number, dependency, configuration value)
+      3. **Determine the verification approach**: Based on the change type, decide how to verify it
+      4. **Extract the specific values**: Note the NEW value that should be present in the current files
+      5. **Setup Gradle TestKit dependency**: Add the following to the root `build.gradle` file:
+         ```groovy
+         dependencies {
+             testImplementation gradleTestKit()
+             testImplementation 'org.junit.jupiter:junit-jupiter:5.9.3'
+             testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+         }
+
+         test {
+             useJUnitPlatform()
+             systemProperty 'sample.buildFile', file('path/to/target/build.gradle').absolutePath
+         }
+         ```
+         Replace `'path/to/target/build.gradle'` with the actual path to the build file that was modified.
+
+         Or for Kotlin DSL (`build.gradle.kts`):
+         ```kotlin
+         dependencies {
+             testImplementation(gradleTestKit())
+             testImplementation("org.junit.jupiter:junit-jupiter:5.9.3")
+             testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+         }
+
+         tasks.test {
+             useJUnitPlatform()
+             systemProperty("sample.buildFile", file("path/to/target/build.gradle.kts").absolutePath)
+         }
+         ```
+         Replace `"path/to/target/build.gradle.kts"` with the actual path to the build file that was modified.
+      6. **Create the test file**: Write `BuildScriptTest.java` in `/src/test/java/`
+      7. **Verify your logic**: Ensure the test PASSES with the current changes
+      8. **Test your solution**: Run `./gradlew :clean :test --tests BuildScriptTest` to verify the test executes correctly.
+      9. **Submit**: Use the submit command to finalize
+
+      ## Example Analysis
+
+      If `git diff HEAD~1` shows:
+      ```diff
+      -mockito_core = "5.20.0"
+      +mockito_core = "5.21.0"
+      ```
+
+      Your test should:
+      - Assert that the file contains `"5.21.0"` (PASSES with current changes)
+      - This verifies the version was updated correctly
+
+      Remember: The test runs against the build file specified by `sample.buildFile` system property. Your assertions must be specific to the exact change you discovered using git.
+    next_step_template: |-
+      OBSERVATION:
+      {{observation}}
+    next_step_no_output_template: |-
+      Your command ran successfully and did not produce any output.
+  tools:
+    env_variables:
+      PAGER: cat
+      MANPAGER: cat
+      LESS: -R
+      PIP_PROGRESS_BAR: 'off'
+      TQDM_DISABLE: '1'
+      GIT_PAGER: cat
+    bundles:
+      - path: tools/registry
+      - path: tools/edit_anthropic
+      - path: tools/review_on_submit_m
+    registry_variables:
+      USE_FILEMAP: 'true'
+      SUBMIT_REVIEW_MESSAGES:
+        - |
+          Thank you for your work on this issue. Please carefully follow the steps below to help review your changes.
+
+          1. If you made any changes to your code after running the reproduction script, please run the reproduction script again.
+            If the reproduction script is failing, please revisit your changes and make sure they are correct.
+            If you have already removed your reproduction script, please ignore this step.
+          2. Remove your reproduction script (if you haven't done so already).
+          3. If you have modified any TEST files, please revert them to the state they had before you started fixing the issue.
+            You can do this with `git checkout -- /path/to/test/file.py`. Use below <diff> to find the files you need to revert.
+          4. Run the submit command again to confirm.
+
+          Here is a list of all of your changes:
+
+          <diff>
+          {{diff}}
+          </diff>
+    execution_timeout: 300
+    enable_bash_tool: true
+    parse_function:
+      type: function_calling

--- a/gradle-bench/README.md
+++ b/gradle-bench/README.md
@@ -17,7 +17,7 @@ python run_pipeline.py [json_file] [model_name]
 ```
 
 - `json_file` — dataset filename inside `data/` (default: `gradle_dataset_verified.json`)
-- `model_name` — LLM model to use for test generation (default: `claude-sonnet-4-6`)
+- `model_name` — LLM model to use for test generation (default: `claude-sonnet-4-6`). Accepts any model supported by [litellm](https://docs.litellm.ai/docs/providers) (e.g. `claude-opus-4-6`, `gpt-4o`, `gemini/gemini-2.5-flash`). Requires the corresponding API key in the environment (e.g. `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`).
 
 Example:
 
@@ -31,24 +31,28 @@ python run_pipeline.py gradle_dataset_verified_sample.json claude-opus-4-6
 
 ### 1. Prepare — `preprocess_dataset.py`
 
-**Input:** a raw JSON dataset (list of SWE-bench instances) in `data/`.  
+**Input:** a raw JSON dataset (list of SWE-bench instances) in `data/`.
 **Output:** the same file updated in-place.
 
 Adds two fields that SWE-agent requires but are absent from the raw export:
 
 | Field | Value |
 |---|---|
-| `image_name` | Docker image tag derived from `instance_id` |
+| `image_name` | Docker image tag derived from `instance_id`, with `{arch}` placeholder |
 | `repo_name` | Fixed to `testbed` (the in-container checkout path) |
 
 Also ensures every `patch` value ends with a newline, as required by the patch-apply tooling.
+
+The `image_name` uses a literal `{arch}` placeholder (e.g. `sweb.eval.{arch}.aliucord__aliucord-556:latest`) so the dataset remains portable across architectures. The placeholder is resolved to the current machine architecture (`arm64`, `x86_64`, etc.) at runtime — either by `run_pipeline.py` (step 1b) or by `agent_generate_tests.sh` when run standalone.
 
 ---
 
 ### 2. Generate — `agent_generate_tests.sh`
 
-**Input:** the preprocessed dataset produced in stage 1.  
+**Input:** the preprocessed dataset produced in stage 1.
 **Output:** a `preds.json` file written to the trajectory directory under `trajectories/`.
+
+Before launching the agent, resolves any `{arch}` placeholders in `image_name` fields to the current machine architecture (via `uname -m`).
 
 Runs `sweagent.run.run_batch` using the `gradle_test_generation` config. The agent is given each issue and asked to write a test that reproduces it. Results (one patch file per instance) are accumulated in a trajectory directory and summarised in `preds.json`.
 
@@ -56,7 +60,7 @@ Runs `sweagent.run.run_batch` using the `gradle_test_generation` config. The age
 
 ### 3. Collect — `populate_test_patches.py`
 
-**Input:** the preprocessed dataset and the `preds.json` from stage 2.  
+**Input:** the preprocessed dataset and the `preds.json` from stage 2.
 **Output:** a new JSON file (`data/<stem>_with_test_patch.json`) containing only the instances for which the agent produced a non-empty test patch.
 
 Reads the agent predictions, copies the `model_patch` value into the `test_patch` field of each matching dataset entry, and writes the filtered result to the output file. The `preds.json` is resolved automatically from `trajectories/` by matching the dataset filename stem; the most recently modified match is used.

--- a/gradle-bench/README.md
+++ b/gradle-bench/README.md
@@ -43,7 +43,7 @@ Adds two fields that SWE-agent requires but are absent from the raw export:
 
 Also ensures every `patch` value ends with a newline, as required by the patch-apply tooling.
 
-The `image_name` uses a literal `{arch}` placeholder (e.g. `sweb.eval.{arch}.aliucord__aliucord-556:latest`) so the dataset remains portable across architectures. The placeholder is resolved to the current machine architecture (`arm64`, `x86_64`, etc.) at runtime — either by `run_pipeline.py` (step 1b) or by `agent_generate_tests.sh` when run standalone.
+The `image_name` uses a literal `{arch}` placeholder (e.g. `sweb.eval.{arch}.aliucord__aliucord-556:latest`) so the dataset remains portable across architectures. The placeholder is resolved at runtime by probing Docker for the actual image — the host architecture is tried first, then the alternative (`x86_64` on ARM hosts, `arm64` on x86 hosts). This handles repos that force a specific architecture (e.g. projects using older Kotlin/Native versions that only ship x86_64 binaries).
 
 ---
 
@@ -52,7 +52,7 @@ The `image_name` uses a literal `{arch}` placeholder (e.g. `sweb.eval.{arch}.ali
 **Input:** the preprocessed dataset produced in stage 1.
 **Output:** a `preds.json` file written to the trajectory directory under `trajectories/`.
 
-Before launching the agent, resolves any `{arch}` placeholders in `image_name` fields to the current machine architecture (via `uname -m`).
+Before launching the agent, resolves any `{arch}` placeholders in `image_name` fields by probing Docker for the locally available image.
 
 Runs `sweagent.run.run_batch` using the `gradle_test_generation` config. The agent is given each issue and asked to write a test that reproduces it. Results (one patch file per instance) are accumulated in a trajectory directory and summarised in `preds.json`.
 

--- a/gradle-bench/agent_generate_tests.sh
+++ b/gradle-bench/agent_generate_tests.sh
@@ -1,24 +1,59 @@
 MODEL_NAME="${1:-claude-sonnet-4-6}"
 DATASET_FILE="${2:-gradle-bench/data/gradle_dataset_verified.json}"
 
-# Resolve {arch} placeholders in image_name fields to the current machine architecture
-ARCH="$(uname -m)"
+# Resolve {arch} placeholders by probing Docker for the actual image architecture
+# Normalize: Linux ARM reports "aarch64" but Docker image tags use "arm64"
+HOST_ARCH="$(uname -m)"
+case "$HOST_ARCH" in aarch64) HOST_ARCH="arm64" ;; esac
 python -c "
-import json, sys
-with open('$DATASET_FILE') as f: data = json.load(f)
+import json, subprocess
+host_arch = '$HOST_ARCH'
+candidates = [host_arch, 'x86_64'] if host_arch != 'x86_64' else [host_arch, 'arm64']
+with open('$DATASET_FILE') as f:
+    data = json.load(f)
 changed = False
 for inst in data:
-    if '{arch}' in inst.get('image_name', ''):
-        inst['image_name'] = inst['image_name'].replace('{arch}', '$ARCH')
+    if '{arch}' not in inst.get('image_name', ''):
+        continue
+    resolved = False
+    for arch in candidates:
+        candidate = inst['image_name'].replace('{arch}', arch)
+        if subprocess.run(['docker', 'inspect', candidate], capture_output=True).returncode == 0:
+            inst['image_name'] = candidate
+            print(f'  {inst[\"instance_id\"]:50s} -> {arch}')
+            resolved = True
+            changed = True
+            break
+    if not resolved:
+        inst['image_name'] = inst['image_name'].replace('{arch}', host_arch)
+        print(f'  {inst[\"instance_id\"]:50s} -> {host_arch} (no image found)')
         changed = True
 if changed:
-    with open('$DATASET_FILE', 'w') as f: json.dump(data, f, indent=2)
-    print(f'Resolved image architecture to $ARCH for {len(data)} instances')
+    with open('$DATASET_FILE', 'w') as f:
+        json.dump(data, f, indent=2)
 "
 
+# Select config based on model provider
+case "$MODEL_NAME" in
+  gemini/*) CONFIG="config/gradle_test_generation_gemini.yaml" ;;
+  *)        CONFIG="config/gradle_test_generation.yaml" ;;
+esac
+
+# If any instance uses an x86_64 image, set platform to linux/amd64 so Docker
+# uses QEMU emulation for those while still running arm64 images natively.
+if grep -q 'x86_64' "$DATASET_FILE"; then
+  PLATFORM="linux/amd64"
+else
+  case "$(uname -m)" in
+    arm64|aarch64) PLATFORM="linux/arm64/v8" ;;
+    *)             PLATFORM="linux/amd64" ;;
+  esac
+fi
+
 python -m sweagent.run.run_batch \
-  --config config/gradle_test_generation.yaml \
+  --config "$CONFIG" \
   --instances.type file \
   --instances.path "$DATASET_FILE" \
+  --instances.deployment.platform "$PLATFORM" \
   --agent.model.name "$MODEL_NAME" \
   --num_workers 5

--- a/gradle-bench/agent_generate_tests.sh
+++ b/gradle-bench/agent_generate_tests.sh
@@ -1,6 +1,21 @@
 MODEL_NAME="${1:-claude-sonnet-4-6}"
 DATASET_FILE="${2:-gradle-bench/data/gradle_dataset_verified.json}"
 
+# Resolve {arch} placeholders in image_name fields to the current machine architecture
+ARCH="$(uname -m)"
+python -c "
+import json, sys
+with open('$DATASET_FILE') as f: data = json.load(f)
+changed = False
+for inst in data:
+    if '{arch}' in inst.get('image_name', ''):
+        inst['image_name'] = inst['image_name'].replace('{arch}', '$ARCH')
+        changed = True
+if changed:
+    with open('$DATASET_FILE', 'w') as f: json.dump(data, f, indent=2)
+    print(f'Resolved image architecture to $ARCH for {len(data)} instances')
+"
+
 python -m sweagent.run.run_batch \
   --config config/gradle_test_generation.yaml \
   --instances.type file \

--- a/gradle-bench/preprocess_dataset.py
+++ b/gradle-bench/preprocess_dataset.py
@@ -20,54 +20,54 @@ import sys
 from pathlib import Path
 
 
-def preprocess_dataset(json_path='gradle_prs_swe_bench_trimmed.json'):
+def preprocess_dataset(json_path="gradle_prs_swe_bench_trimmed.json"):
     """Preprocess SWE-bench dataset instances.
-    
+
     Adds image_name and repo_name fields and appends newlines to patch fields.
-    
+
     Args:
         json_path: Path to the JSON file containing instances
     """
     json_path = Path(json_path)
-    
+
     if not json_path.exists():
         print(f"Error: File not found: {json_path}")
         sys.exit(1)
-    
+
     # Load the JSON file
     print(f"Loading instances from: {json_path}")
-    with open(json_path, 'r') as f:
+    with open(json_path) as f:
         instances = json.load(f)
-    
+
     print(f"Processing {len(instances)} instances...\n")
-    
+
     # Preprocess each instance
     for i, instance in enumerate(instances, 1):
-        instance_id = instance['instance_id']
+        instance_id = instance["instance_id"]
 
-        # Standard SWE-bench image naming convention
-        image_name = f'sweb.eval.x86_64.{instance_id.lower()}:latest'
-        instance['image_name'] = image_name
-        
+        # Architecture-agnostic; {arch} is resolved at runtime by the pipeline
+        image_name = f"sweb.eval.{{arch}}.{instance_id.lower()}:latest"
+        instance["image_name"] = image_name
+
         # Add repo_name field
-        instance['repo_name'] = 'testbed'
-        
+        instance["repo_name"] = "testbed"
+
         # Add newline to patch field
-        if 'patch' in instance and instance['patch']:
-            if not instance['patch'].endswith('\n'):
-                instance['patch'] += '\n'
-        
+        if instance.get("patch"):
+            if not instance["patch"].endswith("\n"):
+                instance["patch"] += "\n"
+
         print(f"  [{i:2d}] {instance_id:50s} → {image_name}")
-    
+
     # Save updated JSON in-place
-    with open(json_path, 'w') as f:
+    with open(json_path, "w") as f:
         json.dump(instances, f, indent=2)
-    
+
     print(f"\n✓ Updated JSON saved to: {json_path}")
     print(f"\n{len(instances)} instances preprocessed successfully!")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # Get JSON file path from command line argument or use default
-    json_file = sys.argv[1] if len(sys.argv) > 1 else 'gradle_prs_swe_bench_with_tests.json'
+    json_file = sys.argv[1] if len(sys.argv) > 1 else "gradle_prs_swe_bench_with_tests.json"
     preprocess_dataset(json_file)

--- a/gradle-bench/run_pipeline.py
+++ b/gradle-bench/run_pipeline.py
@@ -25,17 +25,41 @@ def run(cmd: list[str], cwd: Path) -> None:
         sys.exit(result.returncode)
 
 
+def _docker_image_exists(image: str) -> bool:
+    return (
+        subprocess.run(
+            ["docker", "inspect", image],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        ).returncode
+        == 0
+    )
+
+
 def resolve_arch(json_path: Path) -> None:
-    """Replace {arch} placeholders in image_name with the current machine architecture."""
-    arch = platform.machine()
+    """Replace {arch} placeholders by probing Docker for the actual image architecture."""
+    host_arch = platform.machine()
+    # Normalize: Linux ARM reports "aarch64" but Docker image tags use "arm64"
+    if host_arch == "aarch64":
+        host_arch = "arm64"
+    candidates = [host_arch, "x86_64"] if host_arch != "x86_64" else [host_arch, "arm64"]
+
     with open(json_path) as f:
         instances = json.load(f)
     for instance in instances:
-        if "image_name" in instance:
-            instance["image_name"] = instance["image_name"].replace("{arch}", arch)
+        if "{arch}" not in instance.get("image_name", ""):
+            continue
+        for arch in candidates:
+            candidate = instance["image_name"].replace("{arch}", arch)
+            if _docker_image_exists(candidate):
+                instance["image_name"] = candidate
+                print(f"  {instance['instance_id']:50s} → {arch}")
+                break
+        else:
+            instance["image_name"] = instance["image_name"].replace("{arch}", host_arch)
+            print(f"  {instance['instance_id']:50s} → {host_arch} (no image found)")
     with open(json_path, "w") as f:
         json.dump(instances, f, indent=2)
-    print(f"Resolved image architecture to '{arch}' for {len(instances)} instances")
 
 
 def main() -> None:

--- a/gradle-bench/run_pipeline.py
+++ b/gradle-bench/run_pipeline.py
@@ -12,6 +12,8 @@ If no file is specified, defaults to 'data/gradle_dataset_verified.json'.
 If no model is specified, defaults to 'claude-sonnet-4-6'.
 """
 
+import json
+import platform
 import subprocess
 import sys
 from pathlib import Path
@@ -21,6 +23,19 @@ def run(cmd: list[str], cwd: Path) -> None:
     result = subprocess.run(cmd, cwd=cwd)
     if result.returncode != 0:
         sys.exit(result.returncode)
+
+
+def resolve_arch(json_path: Path) -> None:
+    """Replace {arch} placeholders in image_name with the current machine architecture."""
+    arch = platform.machine()
+    with open(json_path) as f:
+        instances = json.load(f)
+    for instance in instances:
+        if "image_name" in instance:
+            instance["image_name"] = instance["image_name"].replace("{arch}", arch)
+    with open(json_path, "w") as f:
+        json.dump(instances, f, indent=2)
+    print(f"Resolved image architecture to '{arch}' for {len(instances)} instances")
 
 
 def main() -> None:
@@ -35,6 +50,9 @@ def main() -> None:
         [sys.executable, "preprocess_dataset.py", dataset_file],
         cwd=script_dir,
     )
+
+    print("\n=== Step 1b: Resolving image architecture ===")
+    resolve_arch(script_dir / dataset_file)
 
     print("\n=== Step 2: Generating test patches with SWE-agent ===")
     run(


### PR DESCRIPTION
resolve Docker image architecture at runtime instead of hardcoding x86_64
- The preprocessed dataset now stores a portable {arch} placeholder in image_name fields. The placeholder is resolved to the current machine architecture (arm64, x86_64, etc.) at pipeline runtime — both via run_pipeline.py and when agent_generate_tests.sh is run standalone.

Detect Docker arch in order to support cross-arch
- Update architecture resolution to probe Docker for existing images instead of relying on the host architecture. This ensures compatibility with repositories that only support specific platforms, such as those using legacy Kotlin/Native binaries.

Also introduce a Gemini-compatible configuration that omits unsupported history processors, and update the execution scripts to use it for Gemini-based models.


