### PR TITLE
Add automatic arch splitting and merging to pipelin, also adjust config in order to prevent agent timeouts

### DIFF
--- a/config/gradle_test_generation.yaml
+++ b/config/gradle_test_generation.yaml
@@ -188,7 +188,7 @@ agent:
           <diff>
           {{diff}}
           </diff>
-    execution_timeout: 300
+    execution_timeout: 600
     enable_bash_tool: true
     parse_function:
       type: function_calling

--- a/config/gradle_test_generation_gemini.yaml
+++ b/config/gradle_test_generation_gemini.yaml
@@ -2,6 +2,8 @@
 # Omits cache_control history processor (incompatible with Gemini's CachedContent API)
 agent:
   type: default
+  model:
+    per_instance_cost_limit: 5.0
   templates:
     system_template: |-
       You are an expert in Gradle build systems and test generation. Your task is to generate Gradle Test Kit tests that verify specific build script changes.
@@ -188,7 +190,7 @@ agent:
           <diff>
           {{diff}}
           </diff>
-    execution_timeout: 300
+    execution_timeout: 600
     enable_bash_tool: true
     parse_function:
       type: function_calling

--- a/gradle-bench/README.md
+++ b/gradle-bench/README.md
@@ -10,6 +10,8 @@ The pipeline takes a raw Gradle dataset and produces a refined dataset where eve
 2. **Generate** — run the SWE-agent to produce test patches for each issue.
 3. **Collect** — merge the generated patches back into the dataset, keeping only entries for which a patch was produced.
 
+When the dataset contains images built for different architectures (e.g. arm64 and x86_64), the pipeline automatically splits them into per-arch batches, runs each with the correct Docker platform, and merges the results before stage 3.
+
 Run the full pipeline with:
 
 ```bash
@@ -52,9 +54,15 @@ The `image_name` uses a literal `{arch}` placeholder (e.g. `sweb.eval.{arch}.ali
 **Input:** the preprocessed dataset produced in stage 1.
 **Output:** a `preds.json` file written to the trajectory directory under `trajectories/`.
 
-Before launching the agent, resolves any `{arch}` placeholders in `image_name` fields by probing Docker for the locally available image.
+**Arguments:** `<model_name> <dataset_file> <platform>`
 
-Runs `sweagent.run.run_batch` using the `gradle_test_generation` config. The agent is given each issue and asked to write a test that reproduces it. Results (one patch file per instance) are accumulated in a trajectory directory and summarised in `preds.json`.
+- `model_name` -- LLM model (default: `claude-sonnet-4-6`)
+- `dataset_file` -- path to the dataset JSON (default: `gradle-bench/data/gradle_dataset_verified.json`)
+- `platform` -- Docker platform string (default: `linux/amd64`). Use `linux/arm64/v8` for native ARM images.
+
+Runs `sweagent.run.run_batch` using the `gradle_test_generation` config (or `gradle_test_generation_gemini` for Gemini models). The agent is given each issue and asked to write a test that reproduces it. Results (one patch file per instance) are accumulated in a trajectory directory and summarised in `preds.json`.
+
+When run via `run_pipeline.py`, the platform argument is set automatically based on each batch's architecture. When run standalone, it defaults to `linux/amd64`.
 
 ---
 
@@ -75,8 +83,8 @@ Each stage can also be run independently from the project root:
 # Stage 1
 python gradle-bench/preprocess_dataset.py data/gradle_dataset_verified.json
 
-# Stage 2 — args: [model_name] [dataset_file]
-bash gradle-bench/agent_generate_tests.sh claude-sonnet-4-6 gradle-bench/data/gradle_dataset_verified.json
+# Stage 2 -- args: [model_name] [dataset_file] [platform]
+bash gradle-bench/agent_generate_tests.sh claude-sonnet-4-6 gradle-bench/data/gradle_dataset_verified.json linux/arm64/v8
 
 # Stage 3
 python gradle-bench/populate_test_patches.py data/gradle_dataset_verified.json

--- a/gradle-bench/agent_generate_tests.sh
+++ b/gradle-bench/agent_generate_tests.sh
@@ -1,54 +1,12 @@
 MODEL_NAME="${1:-claude-sonnet-4-6}"
 DATASET_FILE="${2:-gradle-bench/data/gradle_dataset_verified.json}"
-
-# Resolve {arch} placeholders by probing Docker for the actual image architecture
-# Normalize: Linux ARM reports "aarch64" but Docker image tags use "arm64"
-HOST_ARCH="$(uname -m)"
-case "$HOST_ARCH" in aarch64) HOST_ARCH="arm64" ;; esac
-python -c "
-import json, subprocess
-host_arch = '$HOST_ARCH'
-candidates = [host_arch, 'x86_64'] if host_arch != 'x86_64' else [host_arch, 'arm64']
-with open('$DATASET_FILE') as f:
-    data = json.load(f)
-changed = False
-for inst in data:
-    if '{arch}' not in inst.get('image_name', ''):
-        continue
-    resolved = False
-    for arch in candidates:
-        candidate = inst['image_name'].replace('{arch}', arch)
-        if subprocess.run(['docker', 'inspect', candidate], capture_output=True).returncode == 0:
-            inst['image_name'] = candidate
-            print(f'  {inst[\"instance_id\"]:50s} -> {arch}')
-            resolved = True
-            changed = True
-            break
-    if not resolved:
-        inst['image_name'] = inst['image_name'].replace('{arch}', host_arch)
-        print(f'  {inst[\"instance_id\"]:50s} -> {host_arch} (no image found)')
-        changed = True
-if changed:
-    with open('$DATASET_FILE', 'w') as f:
-        json.dump(data, f, indent=2)
-"
+PLATFORM="${3:-linux/amd64}"
 
 # Select config based on model provider
 case "$MODEL_NAME" in
   gemini/*) CONFIG="config/gradle_test_generation_gemini.yaml" ;;
   *)        CONFIG="config/gradle_test_generation.yaml" ;;
 esac
-
-# If any instance uses an x86_64 image, set platform to linux/amd64 so Docker
-# uses QEMU emulation for those while still running arm64 images natively.
-if grep -q 'x86_64' "$DATASET_FILE"; then
-  PLATFORM="linux/amd64"
-else
-  case "$(uname -m)" in
-    arm64|aarch64) PLATFORM="linux/arm64/v8" ;;
-    *)             PLATFORM="linux/amd64" ;;
-  esac
-fi
 
 python -m sweagent.run.run_batch \
   --config "$CONFIG" \

--- a/gradle-bench/agent_generate_tests.sh
+++ b/gradle-bench/agent_generate_tests.sh
@@ -8,7 +8,7 @@ case "$MODEL_NAME" in
   *)        CONFIG="config/gradle_test_generation.yaml" ;;
 esac
 
-python -m sweagent.run.run_batch \
+${PYTHON:-python3} -m sweagent.run.run_batch \
   --config "$CONFIG" \
   --instances.type file \
   --instances.path "$DATASET_FILE" \

--- a/gradle-bench/run_pipeline.py
+++ b/gradle-bench/run_pipeline.py
@@ -62,12 +62,83 @@ def resolve_arch(json_path: Path) -> None:
         json.dump(instances, f, indent=2)
 
 
+ARCH_TO_PLATFORM = {
+    "arm64": "linux/arm64/v8",
+    "x86_64": "linux/amd64",
+}
+
+
+def _extract_arch(image_name: str) -> str:
+    """Extract the architecture from a resolved image name like 'sweb.eval.arm64.foo:latest'."""
+    parts = image_name.split(".")
+    # Format: sweb.eval.<arch>.<instance_id>:latest
+    if len(parts) >= 3:
+        return parts[2]
+    return "unknown"
+
+
+def group_by_arch(json_path: Path) -> dict[str, list[dict]]:
+    """Read the dataset and group instances by the arch in their image_name."""
+    with open(json_path) as f:
+        instances = json.load(f)
+    groups: dict[str, list[dict]] = {}
+    for instance in instances:
+        arch = _extract_arch(instance.get("image_name", ""))
+        groups.setdefault(arch, []).append(instance)
+    return groups
+
+
+def run_generate(
+    model_name: str,
+    dataset_path: Path,
+    platform: str,
+    project_root: Path,
+) -> None:
+    """Run agent_generate_tests.sh for a single arch group."""
+    dataset_rel = str(dataset_path.relative_to(project_root))
+    result = subprocess.run(
+        ["bash", "gradle-bench/agent_generate_tests.sh", model_name, dataset_rel, platform],
+        cwd=project_root,
+    )
+    # Don't exit on failure -- SWE-agent writes partial results for instances that succeeded
+    if result.returncode != 0:
+        print(f"  Warning: batch exited with code {result.returncode} (partial results may exist)")
+
+
+def merge_preds(
+    arch_groups: dict[str, list[dict]],
+    tmp_files: dict[str, Path],
+    original_stem: str,
+    trajectories_dir: Path,
+) -> None:
+    """Find preds.json from each arch batch and merge into one file
+    under a trajectory directory named after the original dataset stem."""
+    merged: dict = {}
+    for arch, tmp_path in tmp_files.items():
+        stem = tmp_path.stem
+        matches = [p for p in trajectories_dir.rglob("preds.json") if stem in p.parent.name]
+        if not matches:
+            print(f"  Warning: no preds.json found for {arch} batch")
+            continue
+        preds_path = max(matches, key=lambda p: p.stat().st_mtime)
+        with open(preds_path) as f:
+            merged.update(json.load(f))
+
+    # Write merged preds into a directory the collect step can find by original stem
+    merged_dir = trajectories_dir / f"merged___{original_stem}"
+    merged_dir.mkdir(parents=True, exist_ok=True)
+    with open(merged_dir / "preds.json", "w") as f:
+        json.dump(merged, f, indent=4)
+    print(f"  Merged predictions from {len(tmp_files)} batches ({len(merged)} instances)")
+
+
 def main() -> None:
     script_dir = Path(__file__).resolve().parent
     project_root = script_dir.parent
 
     dataset_file = f"data/{sys.argv[1]}" if len(sys.argv) > 1 else "data/gradle_dataset_verified.json"
     model_name = sys.argv[2] if len(sys.argv) > 2 else "claude-sonnet-4-6"
+    dataset_path = script_dir / dataset_file
 
     print("=== Step 1: Preprocessing dataset ===")
     run(
@@ -76,13 +147,39 @@ def main() -> None:
     )
 
     print("\n=== Step 1b: Resolving image architecture ===")
-    resolve_arch(script_dir / dataset_file)
+    resolve_arch(dataset_path)
 
     print("\n=== Step 2: Generating test patches with SWE-agent ===")
-    run(
-        ["bash", "gradle-bench/agent_generate_tests.sh", model_name, f"gradle-bench/{dataset_file}"],
-        cwd=project_root,
-    )
+    arch_groups = group_by_arch(dataset_path)
+
+    if len(arch_groups) == 1:
+        # Single-arch fast path: no temp files, no merge
+        arch = next(iter(arch_groups))
+        platform = ARCH_TO_PLATFORM.get(arch, "linux/amd64")
+        run_generate(model_name, dataset_path, platform, project_root)
+    else:
+        # Multi-arch: split, run per group, merge
+        counts = ", ".join(f"{len(insts)} {arch}" for arch, insts in arch_groups.items())
+        print(f"Mixed architectures detected: {counts}")
+
+        tmp_files: dict[str, Path] = {}
+        for arch, instances in arch_groups.items():
+            platform = ARCH_TO_PLATFORM.get(arch, "linux/amd64")
+            tmp_path = dataset_path.parent / f".tmp_{arch}.json"
+            with open(tmp_path, "w") as f:
+                json.dump(instances, f, indent=2)
+            tmp_files[arch] = tmp_path
+
+            print(f"\nRunning {arch} batch ({platform})...")
+            run_generate(model_name, tmp_path, platform, project_root)
+
+        print("\nMerging predictions...")
+        trajectories_dir = project_root / "trajectories"
+        merge_preds(arch_groups, tmp_files, dataset_path.stem, trajectories_dir)
+
+        # Cleanup temp files
+        for tmp_path in tmp_files.values():
+            tmp_path.unlink(missing_ok=True)
 
     print("\n=== Step 3: Populating dataset with test patches ===")
     run(

--- a/gradle-bench/run_pipeline.py
+++ b/gradle-bench/run_pipeline.py
@@ -96,9 +96,11 @@ def run_generate(
 ) -> None:
     """Run agent_generate_tests.sh for a single arch group."""
     dataset_rel = str(dataset_path.relative_to(project_root))
+    env = {**subprocess.os.environ, "PYTHON": sys.executable}
     result = subprocess.run(
         ["bash", "gradle-bench/agent_generate_tests.sh", model_name, dataset_rel, platform],
         cwd=project_root,
+        env=env,
     )
     # Don't exit on failure -- SWE-agent writes partial results for instances that succeeded
     if result.returncode != 0:


### PR DESCRIPTION
When the dataset contains images for multiple architectures (e.g. arm64
and x86_64), the pipeline now splits them into per-arch batches, runs
each with the correct Docker platform, and merges the preds.json files
before the collection step. Single-arch datasets take the fast path
with no overhead.

Increase execution timeout to accommodate longer test generation tasks.
Also increase the default cost limit for Gemini models to allow execution time to complete.